### PR TITLE
feat: using enumeration for event hooks instead of strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+build
+dist
+ivy.egg-info
+__pycache__
+*~
+*.pyc

--- a/ivy/__init__.py
+++ b/ivy/__init__.py
@@ -54,6 +54,6 @@ def main():
     extensions.load_theme_extensions()
 
     # Fire the primary sequence of event hooks.
-    events.fire('init')
-    events.fire('main')
-    events.fire('exit')
+    events.fire(events.Event.INIT)
+    events.fire(events.Event.MAIN)
+    events.fire(events.Event.EXIT)

--- a/ivy/cli/__init__.py
+++ b/ivy/cli/__init__.py
@@ -49,5 +49,5 @@ argparser = argslib.ArgParser(helptext, ivy.__version__)
 # Parse the application's command-line arguments. Plugins can use the `cli`
 # event to register their own custom commands.
 def parse_args():
-    ivy.events.fire('cli', argparser)
+    ivy.events.fire(ivy.events.Event.CLI, argparser)
     argparser.parse()

--- a/ivy/cli/add.py
+++ b/ivy/cli/add.py
@@ -62,7 +62,7 @@ sibi conscios nisi pollutum obstrictumque meritis suis principem passuros.
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     cmd_parser = argparser.command("add", helptext, cmd_callback)
     cmd_parser.option("title t")

--- a/ivy/cli/build.py
+++ b/ivy/cli/build.py
@@ -33,7 +33,7 @@ Flags:
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     cmd_parser = argparser.command("build", helptext, cmd_callback)
     cmd_parser.flag("clear c")
@@ -49,14 +49,14 @@ def cmd_callback(cmd_name, cmd_parser):
         utils.cleardir(site.out())
         hashes.clear()
 
-    @events.register('main')
+    @events.register(events.Event.MAIN)
     def fire_build_events():
-        events.fire('init_build')
-        events.fire('main_build')
-        events.fire('exit_build')
+        events.fire(events.Event.INIT_BUILD)
+        events.fire(events.Event.MAIN_BUILD)
+        events.fire(events.Event.EXIT_BUILD)
 
 
-@events.register('main_build')
+@events.register(events.Event.MAIN_BUILD)
 def build_site():
     # Make sure we have a valid theme directory.
     if not site.theme():
@@ -83,7 +83,7 @@ def build_site():
     nodes.root().walk(build_node)
 
 
-@events.register('exit_build')
+@events.register(events.Event.EXIT_BUILD)
 def print_build_stats():
     report = datetime.datetime.now().strftime("[%H:%M:%S]")
     report += f"   ·   Rendered: {site.pages_rendered():5d}"

--- a/ivy/cli/clear.py
+++ b/ivy/cli/clear.py
@@ -21,7 +21,7 @@ Flags:
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     argparser.command("clear", helptext, cmd_callback)
 

--- a/ivy/cli/deploy.py
+++ b/ivy/cli/deploy.py
@@ -28,7 +28,7 @@ Flags:
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     argparser.command("deploy", helptext, cmd_callback)
 
@@ -43,7 +43,7 @@ def cmd_callback(cmd_name, cmd_parser):
         path = os.path.join(site.home(), script)
         os.system(path)
 
-    @events.register('main')
+    @events.register(events.Event.MAIN)
     def fire_deploy_event():
-        events.fire('deploy')
+        events.fire(events.Event.DEPLOY)
 

--- a/ivy/cli/init.py
+++ b/ivy/cli/init.py
@@ -24,7 +24,7 @@ Flags:
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     argparser.command("init", helptext, cmd_callback)
 

--- a/ivy/cli/open.py
+++ b/ivy/cli/open.py
@@ -7,6 +7,7 @@ import sys
 import webbrowser
 import os
 
+from .. import events
 
 helptext = """
 Usage: ivy open [url]
@@ -23,7 +24,7 @@ Flags:
 """
 
 
-@ivy.events.register('cli')
+@ivy.events.register(events.Event.CLI)
 def register_command(argparser):
     argparser.command("open", helptext, cmd_callback)
 

--- a/ivy/cli/serve.py
+++ b/ivy/cli/serve.py
@@ -35,7 +35,7 @@ Flags:
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     cmd_parser = argparser.command("serve", helptext, cmd_callback)
     cmd_parser.option("directory d")

--- a/ivy/cli/tree.py
+++ b/ivy/cli/tree.py
@@ -35,7 +35,7 @@ Flags:
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     cmd_parser = argparser.command("tree", helptext, cmd_callback)
     cmd_parser.flag("slugs s")
@@ -46,7 +46,7 @@ def register_command(argparser):
 def cmd_callback(cmd_name, cmd_parser):
     base = 'slug' if cmd_parser.found('slugs') else 'url'
 
-    @events.register('main')
+    @events.register(events.Event.MAIN)
     def tree_callback():
         if not site.home():
             sys.exit("Error: cannot locate the site's home directory.")

--- a/ivy/cli/watch.py
+++ b/ivy/cli/watch.py
@@ -32,7 +32,7 @@ Flags:
 """
 
 
-@events.register('cli')
+@events.register(events.Event.CLI)
 def register_command(argparser):
     cmd_parser = argparser.command("watch", helptext, cmd_callback)
     cmd_parser.flag("clear c")

--- a/ivy/events.py
+++ b/ivy/events.py
@@ -2,9 +2,27 @@
 # This module implements the event API for extensions.
 # ------------------------------------------------------------------------------
 
+from enum import Enum, unique
+
 # Dictionary mapping hook names to lists of callback functions indexed by order.
 _callbacks = {}
 
+# Enumeration of available events. String names are supported for backward
+# compatibility.
+@unique
+class Event(Enum):
+    """All events that Ivy understands are listed here."""
+    CLI = "cli"
+    EXIT = "exit"
+    EXIT_BUILD = "exit_build"
+    INIT_BUILD = "init_build"
+    INIT = "init"
+    MAIN = "main"
+    MAIN_BUILD = "main_build"
+    RENDER_PAGE = "render_page"
+
+# Name-to-value lookup table for Event to support backward compatibility.
+EVENT_NAMES = {member.value: member for member in Event}
 
 # Decorator function for registering event callbacks, i.e. handler functions
 # which will be called when the corresponding event hook is fired.
@@ -14,7 +32,11 @@ _callbacks = {}
 #
 # The @register decorator accepts an optional order parameter with a default
 # integer value of 0. Callbacks with lower order are called first.
+#
+# The hook parameter must be an Event or the name of an Event; the latter
+# is translated into the former.
 def register(hook, order=0):
+    hook = _hook_enum("register", hook)
 
     def register_callback(callback):
         _callbacks.setdefault(hook, {}).setdefault(order, []).append(callback)
@@ -25,11 +47,13 @@ def register(hook, order=0):
 
 # Register an event callback directly without using a decorator.
 def register_callback(hook, callback, order=0):
+    hook = _hook_enum("register_callback", hook)
     _callbacks.setdefault(hook, {}).setdefault(order, []).append(callback)
 
 
 # Fires an event hook.
 def fire(hook, *args):
+    hook = _hook_enum("fire", hook)
     for order in sorted(_callbacks.get(hook, {})):
         for func in _callbacks[hook][order]:
             func(*args)
@@ -37,14 +61,25 @@ def fire(hook, *args):
 
 # Clear all callbacks registered on a hook.
 def clear(hook):
+    hook = _hook_enum("clear", hook)
     _callbacks[hook] = {}
 
 
 # Deregister a callback from a hook.
 def deregister(hook, callback, order=None):
+    hook = _hook_enum("deregister", hook)
     if order is None:
         for order in _callbacks.get(hook, {}):
             if callback in _callbacks[hook][order]:
                 _callbacks[hook][order].remove(callback)
     elif order in _callbacks[hook] and callback in _callbacks[hook][order]:
         _callbacks[hook][order].remove(callback)
+
+
+# Ensure that hook identifier is an Event.
+def _hook_enum(caller, hook):
+    if isinstance(hook, Event):
+        return hook
+    assert isinstance(hook, str), f"Hook name is not Event or string {hook}/{type(hook)}"
+    assert hook in EVENT_NAMES, f"Unknown event hook name {hook}"
+    return EVENT_NAMES[hook]

--- a/ivy/ext/ivy_automenu.py
+++ b/ivy/ext/ivy_automenu.py
@@ -22,7 +22,7 @@ cached_menu = None
 
 
 # Register a callback to add an 'automenu' attribute to each page-data dictionary.
-@ivy.events.register('render_page')
+@ivy.events.register(ivy.events.Event.RENDER_PAGE)
 def add_automenu(page_data):
     global cached_menu
     if cached_menu is None:

--- a/ivy/ext/ivy_ibis.py
+++ b/ivy/ext/ivy_ibis.py
@@ -12,7 +12,7 @@ except ImportError:
 if ibis:
 
     # Initialize the template loader.
-    @ivy.events.register('init')
+    @ivy.events.register(ivy.events.Event.INIT)
     def init():
         ibis.loader = ibis.loaders.FileLoader(ivy.site.theme('templates'))
 

--- a/ivy/ext/ivy_jinja.py
+++ b/ivy/ext/ivy_jinja.py
@@ -19,7 +19,7 @@ if jinja2:
 
     # Initialize the Jinja environment on the 'init' event hook.
     # Check the site's config file for custom settings.
-    @ivy.events.register('init')
+    @ivy.events.register(ivy.events.Event.INIT)
     def init():
         settings = {
             'loader': jinja2.FileSystemLoader(ivy.site.theme('templates'))

--- a/ivy/hashes.py
+++ b/ivy/hashes.py
@@ -69,7 +69,7 @@ def _cachefile() -> str:
 
 
 # Load cached page hashes from the last build run.
-@events.register('init')
+@events.register(events.Event.INIT)
 def _load():
     if os.path.isfile(_cachefile()):
         with open(_cachefile(), 'rb') as file:
@@ -78,7 +78,7 @@ def _load():
 
 
 # Cache page hashes to disk for the next build run.
-@events.register('exit')
+@events.register(events.Event.EXIT)
 def _save():
     if _updated:
         if not os.path.isdir(os.path.dirname(_cachefile())):

--- a/ivy/nodes.py
+++ b/ivy/nodes.py
@@ -193,7 +193,7 @@ class Node():
         }
 
         # Generate a HTML page by pouring the node's content into a template.
-        events.fire('render_page', page_data)
+        events.fire(events.Event.RENDER_PAGE, page_data)
         page_html = templates.render(page_data)
         site.pages_rendered(1)
 


### PR DESCRIPTION
Newcomers to the project may find it hard to figure out the processing cycle because there's no central listing of possible event hooks. This PR addresses that:

1.  Add an `Event` enum to `ivy/events.py` listing known event hooks.
1.  Add an `EVENT_NAMES` dict to support string-to-enum translations for backward compatibility.
1.  Register all internal events using enum elements.
1.  Alter all internal event registrations and firings to use enums.

If this PR is useful, I'd be happy to add similar enumerations elsewhere, and to try to add documentation on the enum classes to try to explain the purpose/lifecycle of each element.

This PR also adds a `.gitignore` file to ignore build artifacts.